### PR TITLE
Configure maven and changes some parameters to build a shaded jar including all the dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /.idea/
 /presence.iml
+/Store.jaxb

--- a/pom.xml
+++ b/pom.xml
@@ -12,18 +12,38 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<junit.version>5.8.2</junit.version>
+		<javafx.version>18</javafx.version>
+		<project.mainclass>fr.ensisa.alt.presence.Main</project.mainclass>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-controls</artifactId>
-			<version>18</version>
+			<version>${javafx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics </artifactId>
+			<version>${javafx.version}</version>
+			<classifier>win</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics </artifactId>
+			<version>${javafx.version}</version>
+			<classifier>linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics </artifactId>
+			<version>${javafx.version}</version>
+			<classifier>mac</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-fxml</artifactId>
-			<version>18</version>
+			<version>${javafx.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.dlsc.formsfx</groupId>
@@ -88,6 +108,41 @@
 					<target>17</target>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>${project.mainclass}</Main-Class>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.2</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>${project.mainclass}</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.openjfx</groupId>
 				<artifactId>javafx-maven-plugin</artifactId>
@@ -97,7 +152,7 @@
 						<!-- Default configuration for running with: mvn clean javafx:run -->
 						<id>default-cli</id>
 						<configuration>
-							<mainClass>fr.ensisa.alt.presence.Application</mainClass>
+							<mainClass>${project.mainclass}</mainClass>
 							<launcher>app</launcher>
 							<jlinkZipName>app</jlinkZipName>
 							<jlinkImageName>app</jlinkImageName>

--- a/src/main/java/fr/ensisa/alt/presence/Main.java
+++ b/src/main/java/fr/ensisa/alt/presence/Main.java
@@ -1,0 +1,8 @@
+package fr.ensisa.alt.presence;
+
+public class Main {
+
+	public static void main(String[] args) {
+		Application.main(args);
+	}
+}

--- a/src/main/java/fr/ensisa/alt/presence/controller/ExcelController.java
+++ b/src/main/java/fr/ensisa/alt/presence/controller/ExcelController.java
@@ -23,11 +23,14 @@ public class ExcelController {
 
 	public ExcelController() {
 		try {
-			this.wb = new XSSFWorkbook(new File(Objects.requireNonNull(Controller.class.getResource("Fiche_presence.xlsx")).toURI()));
+			this.wb = new XSSFWorkbook(Objects.requireNonNull(Controller.class.getResourceAsStream("Fiche_presence.xlsx")));
 			this.wb.setSheetName(0, "default");
 			this.sheet = wb.getSheetAt(0);
 			this.wb.cloneSheet(0, "clone");
 			this.wb.setSheetHidden(wb.getSheetIndex("clone"), true);
+		} catch (NullPointerException e) {
+			System.err.println("Impossible d'accéder au fichier xlsx d'origine");
+			e.printStackTrace();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Add shade plugin to embed the dependencies inside the jar.
Had to add a fake main class to include javaFX dependencies : https://stackoverflow.com/questions/52653836/maven-shade-javafx-runtime-components-are-missing
Change the ressources' access from File objects to stream to be used in the jar (instead of local when run via the IDE)